### PR TITLE
Facebook photos now download without risk of save conflicts

### DIFF
--- a/inTouch/FacebookManager.m
+++ b/inTouch/FacebookManager.m
@@ -70,6 +70,7 @@
     // Session opened success
     if (!error && (status == FBSessionStateOpen || status == FBSessionStateOpenTokenExtended)) {
         [DebugLogger log:@"FB session opened" withPriority:facebookManagerPriority];
+        [[NSNotificationCenter defaultCenter] postNotificationName:facebookSessionStateChanged object:nil];
         [self getFriendsList];
         return;
     }
@@ -77,6 +78,7 @@
     // Session closed
     if (status == FBSessionStateClosed || status == FBSessionStateClosedLoginFailed) {
         [DebugLogger log:@"FB session closed or closed with login fail" withPriority:facebookManagerPriority];
+        [[NSNotificationCenter defaultCenter] postNotificationName:facebookSessionStateChanged object:nil];
     }
     
     // Handle any errors

--- a/inTouch/MainViewController.h
+++ b/inTouch/MainViewController.h
@@ -7,7 +7,12 @@
 @property (weak, nonatomic) IBOutlet UILabel *contactName;
 @property (weak, nonatomic) IBOutlet UIImageView *contactPhotoFront;
 
-// Queue photos
+// Contact queues
+@property (strong, nonatomic) NSMutableArray *contactNeverAppearedQueue;
+@property (strong, nonatomic) NSMutableArray *contactAppearedQueue;
+@property (strong, nonatomic) NSMutableDictionary *facebookFriends;
+
+// Queue photos placeholders
 @property (weak, nonatomic) IBOutlet UIImageView *contactPhotoMiddle;
 @property (weak, nonatomic) IBOutlet UIImageView *contactPhotoBottom;
 @property (weak, nonatomic) IBOutlet UIImageView *contactPhotoAnchor;
@@ -21,10 +26,5 @@
 
 // Gesture recognizers
 @property (weak, nonatomic) IBOutlet UITapGestureRecognizer *tapRecognizer;
-
-// Contact queue stuff
-@property (strong, nonatomic) NSMutableArray *contactNeverAppearedQueue;
-@property (strong, nonatomic) NSMutableArray *contactAppearedQueue;
-@property (strong, nonatomic) NSMutableDictionary *facebookFriends;
 
 @end

--- a/inTouch/PickerViewController.m
+++ b/inTouch/PickerViewController.m
@@ -40,6 +40,8 @@ enum {
 }
 
 - (void)viewDidAppear:(BOOL)animated {
+    [super viewDidAppear:animated];
+    
     // Give the appearance of a modal-like dialog
     [UIView animateWithDuration:0.30 animations:^{
        [[self view] setBackgroundColor:[UIColor colorWithRed:0 green:0 blue:0 alpha:0.6]];
@@ -54,6 +56,8 @@ enum {
 }
 
 - (void)viewWillAppear:(BOOL)animated {
+    [super viewWillAppear:animated];
+    
     NSString *fullName = [NSString stringWithFormat:@"%@ %@", [contact nameFirst], [contact nameLast]];
     [contactNameLabel setText:fullName];
     [contactPhotoView setImage:contactPhoto];

--- a/inTouch/SettingsTableViewController.m
+++ b/inTouch/SettingsTableViewController.m
@@ -3,6 +3,7 @@
 #import "AppDelegate.h"
 #import "ContactManager.h"
 #import "FacebookManager.h"
+#import "NotificationStrings.h"
 #import "SettingsTableViewController.h"
 
 @interface SettingsTableViewController () <MFMailComposeViewControllerDelegate>
@@ -20,7 +21,7 @@
     // Listen for fb session state changed notifications from app delegate
     [[NSNotificationCenter defaultCenter] addObserver:self
                                              selector:@selector(updateFacebookNameLabel)
-                                                 name:@"fbSessionStateChanged"
+                                                 name:facebookSessionStateChanged
                                                object:nil];
 }
 


### PR DESCRIPTION
Made background downloading thread-safe by preventing multiple simultaneous downloads for the same picture
